### PR TITLE
Add public answers index page for evaluation results

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -1,0 +1,6 @@
+class AnswersController < ApplicationController
+  def index
+    @questions = Question.where(q_id: 2).order(:id)
+    @answers = Answer.includes(:subject).filter(&:evaluation_response?)
+  end
+end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,2 +1,49 @@
+require "json"
+require "yaml"
+
 class Answer < ApplicationRecord
+  belongs_to :subject, foreign_key: :department, primary_key: :c_code, optional: true
+
+  EVALUATION_SENTINEL = "School Check".freeze
+
+  def content_items
+    return @content_items if defined?(@content_items)
+
+    value = read_attribute(:content)
+    return @content_items = value if value.is_a?(Array)
+    return @content_items = [] if value.blank?
+
+    parsed = JSON.parse(value)
+    @content_items = Array.wrap(parsed)
+  rescue JSON::ParserError
+    begin
+      parsed_yaml = YAML.safe_load(value, permitted_classes: [], aliases: false)
+      @content_items = Array.wrap(parsed_yaml)
+    rescue Psych::SyntaxError
+      @content_items = Array.wrap(value)
+    end
+  end
+
+  def evaluation_response?
+    items = content_items
+    items.first.present? && items.first != EVALUATION_SENTINEL && items.size >= 3
+  end
+
+  def teacher_name
+    evaluation_response? ? content_items.first : nil
+  end
+
+  def evaluation_scores
+    return [] unless evaluation_response?
+
+    content_items[1...-2] || []
+  end
+
+  def good_points
+    evaluation_response? ? content_items[-2] : nil
+  end
+
+  def improvement_points
+    evaluation_response? ? content_items[-1] : nil
+  end
 end

--- a/app/views/answers/index.html.erb
+++ b/app/views/answers/index.html.erb
@@ -1,0 +1,60 @@
+<div class="container my-4">
+  <h1 class="mb-4">授業評価マスタ</h1>
+
+  <div class="table-responsive">
+    <table class="table table-bordered table-striped align-middle">
+      <thead class="table-light">
+        <tr>
+          <th scope="col">ID</th>
+          <th scope="col">学籍番号</th>
+          <th scope="col">学科名</th>
+          <th scope="col">コース名</th>
+          <th scope="col">学年</th>
+          <th scope="col">教員名</th>
+          <th scope="col">評価（15項目）</th>
+          <th scope="col">良い点</th>
+          <th scope="col">悪い点</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% if @answers.any? %>
+          <% @answers.each do |answer| %>
+            <tr>
+              <td><%= answer.id %></td>
+              <td><%= answer.student_number %></td>
+              <td><%= answer.subject&.name || answer.department %></td>
+              <td><%= answer.course %></td>
+              <td>
+                <% grade = answer.grade.to_s %>
+                <%= if grade.blank?
+                      ""
+                    elsif grade.end_with?("年")
+                      grade
+                    else
+                      "#{grade}年"
+                    end %>
+              </td>
+              <td><%= answer.teacher_name %></td>
+              <td>
+                <ol class="mb-0 ps-3">
+                  <% @questions.each_with_index do |question, index| %>
+                    <li class="mb-1">
+                      <div><strong><%= question.question %></strong></div>
+                      <div>回答：<%= answer.evaluation_scores[index] || "-" %></div>
+                    </li>
+                  <% end %>
+                </ol>
+              </td>
+              <td><%= simple_format(answer.good_points.presence || "-") %></td>
+              <td><%= simple_format(answer.improvement_points.presence || "-") %></td>
+            </tr>
+          <% end %>
+        <% else %>
+          <tr>
+            <td colspan="9" class="text-center">表示できる回答がありません。</td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,5 +18,6 @@ Rails.application.routes.draw do
   post "surveys/create", as: :create_surveys
   post "surveys/create2", as: :create_surveys2
   get "surveys/fin", as: :fin
-  
+
+  resources :answers, only: :index
 end


### PR DESCRIPTION
## Summary
- add an AnswersController#index action that prepares teacher evaluation responses
- expose the answers index page at /answers and render a table with the requested fields
- extend the Answer model with helpers to parse stored content, surface teacher names, scores, and comments

## Testing
- bundle exec rails test *(fails: bundler cannot download gems in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_69045e9f8a4083228b8162d182beeba8